### PR TITLE
增加对地区为"其他国家"的支持

### DIFF
--- a/main.py
+++ b/main.py
@@ -144,12 +144,17 @@ class Zlapp(Fudan):
         last_info = get_info.json()
 
         print("◉上一次提交日期为:", last_info["d"]["info"]["date"])
+        # 地区从oldInfo中提取
+        last_area = last_info["d"]["oldInfo"]["area"]
+        print("◉上一次提交的地区是:", last_area)
+        if last_area == "其他国家":
+            pass
+        else:
+            position = last_info["d"]["info"]['geo_api_info']
+            position = json_loads(position)
 
-        position = last_info["d"]["info"]['geo_api_info']
-        position = json_loads(position)
-
-        print("◉上一次提交地址为:", position['formattedAddress'])
-        # print("◉上一次提交GPS为", position["position"])
+            print("◉上一次提交地址为:", position['formattedAddress'])
+            # print("◉上一次提交GPS为", position["position"])
         # print(last_info)
         
         # 改为上海时区
@@ -201,28 +206,45 @@ class Zlapp(Fudan):
         }
 
         print("\n\n◉◉提交中")
-
-        geo_api_info = json_loads(self.last_info["geo_api_info"])
+        
         province = self.last_info["province"]
         city = self.last_info["city"]
-        district = geo_api_info["addressComponent"].get("district", "")
+        area = self.last_info["area"]
+        if area == "其他国家":
+            gwszdd = self.last_info["gwszdd"]
+        else:
+            geo_api_info = json_loads(self.last_info["geo_api_info"])
+            district = geo_api_info["addressComponent"].get("district", "")
         
         while(True):
             print("◉正在识别验证码......")
             code = self.validate_code()
             print("◉验证码为:", code)
-            self.last_info.update(
-                {
-                    "tw": "13",
-                    "province": province,
-                    "city": city,
-                    "area": " ".join((province, city, district)),
-                    #"sfzx": "1",  # 是否在校
-                    #"fxyy": "",  # 返校原因
-                    "code": code,
-
-                }
-            )
+            if area == "其他国家":
+                self.last_info.update(
+                    {
+                        "tw": "13",
+                        "province": province,
+                        "city": city,
+                        "area": area,
+                        "gwszdd": gwszdd,
+                        #"sfzx": "1",  # 是否在校
+                        #"fxyy": "",  # 返校原因
+                        "code": code,
+                    }
+                )
+            else:
+                self.last_info.update(
+                    {
+                        "tw": "13",
+                        "province": province,
+                        "city": city,
+                        "area": " ".join((province, city, district)),
+                        #"sfzx": "1",  # 是否在校
+                        #"fxyy": "",  # 返校原因
+                        "code": code,
+                    }
+                )
             # print(self.last_info)
             save = self.session.post(
                 'https://zlapp.fudan.edu.cn/ncov/wap/fudan/save',


### PR DESCRIPTION
对于地区为"其他国家"的表格填报，也可以正常运行了。
不需要详细地址，只需要填写另一项"所在国家"。自动填写你上次所填写的内容。